### PR TITLE
fix: tag releasing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "reportgenerator"
       ]
+    },
+    "dotnet-version-cli": {
+      "version": "1.1.2",
+      "commands": [
+        "dotnet-version"
+      ]
     }
   }
 }

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -8,20 +8,29 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-        PROJECT_FILE_PATH: ./src/Strings.Abbreviations/Strings.Abbreviations.csproj
+        DOTNET_VERSION: 3.1.401
+        PROJECT_FILE_PATH: src/Strings.Abbreviations/Strings.Abbreviations.csproj
         TAG_FORMAT_PREFIX: v
 
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      
+      - name: Install tools
+        run: dotnet tool restore
         
       - name: Get project version
         id: project_version
         run: |
-          $versionJsonOutput=dotnet version -f ${{ env.PROJECT_FILE_PATH }} --output-format=json
-          $value=$versionJsonOutput | jq -r '.currentVersion'
-          echo ::set-output name=PROJECT_VERSION::$value
+          versionJsonOutput=`dotnet version -f "${{ env.PROJECT_FILE_PATH }}" --output-format=json`
+          versionValue=`echo $versionJsonOutput | jq -r '.currentVersion'`
+          echo ::set-output name=PROJECT_VERSION::$versionValue
 
       - name: Publish NuGet on version change
         id: publish_nuget
@@ -33,6 +42,6 @@ jobs:
 
       - name: Push tag
         run: |
-          $tag=${{ env.TAG_FORMAT_PREFIX }}${{ steps.project_version.outputs.PROJECT_VERSION}}
+          tag=${{ env.TAG_FORMAT_PREFIX }}${{ steps.project_version.outputs.PROJECT_VERSION}}
           git tag $tag
           git push "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" $tag

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -9,18 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
         PROJECT_FILE_PATH: ./src/Strings.Abbreviations/Strings.Abbreviations.csproj
-        # Official NuGet Feed settings
-        NUGET_FEED: https://api.nuget.org/v3/index.json
-        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+        TAG_FORMAT_PREFIX: v
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        
       - name: Get project version
-        id: projectVersion
+        id: project_version
         run: |
           $versionJsonOutput=dotnet version -f ${{ env.PROJECT_FILE_PATH }} --output-format=json
           $value=$versionJsonOutput | jq -r '.currentVersion'
-          echo ::set-output name=PROJECT_VERSION::'$value'
+          echo ::set-output name=PROJECT_VERSION::$value
 
       - name: Publish NuGet on version change
         id: publish_nuget
@@ -29,3 +30,9 @@ jobs:
           PROJECT_FILE_PATH: ${{ env.PROJECT_FILE_PATH }}
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           TAG_COMMIT: false
+
+      - name: Push tag
+        run: |
+          $tag=${{ env.TAG_FORMAT_PREFIX }}${{ steps.project_version.outputs.PROJECT_VERSION}}
+          git tag $tag
+          git push "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" $tag

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -12,6 +12,12 @@ jobs:
         PROJECT_FILE_PATH: src/Strings.Abbreviations/Strings.Abbreviations.csproj
         TAG_FORMAT_PREFIX: v
 
+         # Stop wasting time caching packages
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+        # Disable sending usage data
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,3 +21,11 @@ jobs:
           $versionJsonOutput=dotnet version -f ${{ env.PROJECT_FILE_PATH }} --output-format=json
           $value=$versionJsonOutput | jq -r '.currentVersion'
           echo ::set-output name=PROJECT_VERSION::'$value'
+
+      - name: Publish NuGet on version change
+        id: publish_nuget
+        uses: rohith/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: ${{ env.PROJECT_FILE_PATH }}
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          TAG_COMMIT: false

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,16 +7,17 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+        PROJECT_FILE_PATH: ./src/Strings.Abbreviations/Strings.Abbreviations.csproj
+        # Official NuGet Feed settings
+        NUGET_FEED: https://api.nuget.org/v3/index.json
+        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+
     steps:
       - uses: actions/checkout@v2
-        
-      # uses https://github.com/marketplace/actions/publish-nuget that build, pack & publish 
-      # nuget packages automatically when a project version is updated
-      - name: Publish NuGet on version change
-        id: publish_nuget
-        uses: rohith/publish-nuget@v2
-        with:
-          PROJECT_FILE_PATH: ./src/Strings.Abbreviations/Strings.Abbreviations.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          # Flag to toggle git tagging, enabled by default
-          TAG_COMMIT: true
+      - name: Get project version
+        id: projectVersion
+        run: |
+          $versionJsonOutput=dotnet version -f ${{ env.PROJECT_FILE_PATH }} --output-format=json
+          $value=$versionJsonOutput | jq -r '.currentVersion'
+          echo ::set-output name=PROJECT_VERSION::'$value'


### PR DESCRIPTION
Updated workflow with generating tag, pushing tag and invoking another workflow.

To make it all working you need to setup personal token with name `PERSONAL_ACCESS_TOKEN` with access to repo.

Thanks to this `dotnet tool`: https://github.com/skarpdev/dotnet-version-cli we could get version from `csproj`.

Here are test outputs:
 
 * https://github.com/aochmann/Strings.Abbreviations/runs/1231960967?check_suite_focus=true  - disabled pushing NuGet and creating tag (as it is done outside this step)
 * https://github.com/aochmann/Strings.Abbreviations/actions/runs/297698230  - another workflow was triggered after pushing tag from previous workflow
 * https://github.com/aochmann/Strings.Abbreviations/releases/tag/v0.1.4

Didn't follow workarounds described on issue, because it could made some other issues in the future. 

Fixing issue: https://github.com/kkokosa/Strings.Abbreviations/issues/7

PS: if you could annotate this PR with `hacktoberfest-accepted` label after successfully review